### PR TITLE
chore: align Prisma version

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@nulladata/config": "workspace:*",
     "@nulladata/ui": "workspace:*",
-    "@prisma/client": "^5.9.1",
+    "@prisma/client": "^5.16.1",
     "bullmq": "^4.13.0",
     "ioredis": "^5.3.2",
     "next": "^14.1.0",
@@ -20,7 +20,7 @@
     "react-dom": "^18.2.0",
     "nodemailer": "^6.9.8",
     "pdfkit": "^0.13.0",
-    "prisma": "^5.9.1",
+    "prisma": "^5.16.1",
     "next-auth": "^4.24.5"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@prisma/client':
-        specifier: ^5.9.1
+        specifier: ^5.16.1
         version: 5.22.0(prisma@5.22.0)
       bullmq:
         specifier: ^4.13.0
@@ -94,7 +94,7 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       prisma:
-        specifier: ^5.9.1
+        specifier: ^5.16.1
         version: 5.22.0
       react:
         specifier: ^18.2.0


### PR DESCRIPTION
## Summary
- align `prisma` and `@prisma/client` to `^5.16.1` across workspace
- regenerate lockfile and prisma client

## Testing
- `pnpm install`
- `pnpm prisma generate`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a45bfa18d4832ba66395a87f6e76fe