### PR TITLE
feat: add smtp from configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
+SMTP_FROM=no-reply@localhost
 NEXTAUTH_SECRET=changeme
 NEXTAUTH_URL=http://localhost:3000
 APP_BASE_URL=http://localhost:3000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ SMTP_HOST=localhost
 SMTP_PORT=1025
 SMTP_USER=
 SMTP_PASS=
+SMTP_FROM=no-reply@localhost
 NEXTAUTH_SECRET=changeme
 NEXTAUTH_URL=http://localhost:3000
 APP_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pnpm prisma db seed
 pnpm dev
 ```
 
+Configura le variabili ambiente creando un file `.env` a partire da `.env.example` e impostando `SMTP_FROM` con l'indirizzo mittente desiderato.
+
 Il seed crea un utente admin demo e un caso di esempio con tre targets.
 
 ## Script

--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,23 @@
+import NextAuth, { NextAuthOptions } from 'next-auth'
+import EmailProvider from 'next-auth/providers/email'
+import { env } from '@nulladata/config'
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    EmailProvider({
+      server: {
+        host: env.SMTP_HOST,
+        port: Number(env.SMTP_PORT),
+        auth: {
+          user: env.SMTP_USER,
+          pass: env.SMTP_PASS,
+        },
+      },
+      from: env.SMTP_FROM,
+    }),
+  ],
+}
+
+const handler = NextAuth(authOptions)
+
+export { handler as GET, handler as POST }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -7,6 +7,7 @@ export const env = {
   SMTP_PORT: process.env.SMTP_PORT || '',
   SMTP_USER: process.env.SMTP_USER || '',
   SMTP_PASS: process.env.SMTP_PASS || '',
+  SMTP_FROM: process.env.SMTP_FROM || '',
   NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET || '',
   NEXTAUTH_URL: process.env.NEXTAUTH_URL || '',
   APP_BASE_URL: process.env.APP_BASE_URL || '',


### PR DESCRIPTION
## Summary
- add `SMTP_FROM` variable to env example and docs
- expose `SMTP_FROM` via config package
- use `SMTP_FROM` in NextAuth email provider

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Property '$disconnect' does not exist on type 'PrismaClient')*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a45bf8949c832ba65a3f438797dceb